### PR TITLE
Reconnect to ZK only after 1 second

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -87,10 +87,12 @@ Client.prototype.connect = function () {
     zk.once('disconnected', function () {
         if (!zk.closed) {
             zk.close();
-            self.connect();
-            self.emit('zkReconnect');
+            setTimeout(function () {
+                self.connect();
+                self.emit('zkReconnect');
+            }, 1000);
         }
-    })
+    });
     zk.on('error', function (err) {
         self.emit('error', err);
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmf-kafka-node",
   "description": "node client for Apache kafka, only support kafka 0.8 and above",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "kafka.js",
   "dependencies": {
     "async": ">0.9 <2.0",


### PR DESCRIPTION
Without a timeout we have tons of workers and tons of connections, so they emit tons of reconnects every second bringing down the whole node.

cc @d00rman 
