### PR TITLE
Reconnect manually only when the session expired

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -83,13 +83,12 @@ Client.prototype.connect = function () {
             self.emit('brokersChanged');
         }, 3000);
     });
-    zk.once('disconnected', function () {
+    zk.once('expired', function () {
+        // We were disconnected for too long and session expired - recreate the client
         if (!zk.closed) {
             zk.close();
-            setTimeout(function () {
-                self.connect();
-                self.emit('zkReconnect');
-            }, Math.floor(Math.random() * 1000) + 1000);
+            self.connect();
+            self.emit('zkReconnect');
         }
     });
     zk.on('error', function (err) {

--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -24,6 +24,9 @@ var Zookeeper = function (connectionString, options) {
     this.client.on('disconnected', function () {
         that.emit('disconnected');
     });
+    this.client.on('expired', function () {
+        that.emit('expired');
+    });
     this.client.connect();
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmf-kafka-node",
   "description": "node client for Apache kafka, only support kafka 0.8 and above",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "kafka.js",
   "dependencies": {
     "async": ">0.9 <2.0",


### PR DESCRIPTION
ZK client does a great job reconnecting for brief network interruptions. But if ZK was down longer the session timeout, ZK client becomes useless and needs to be recreated.

cc @d00rman 
