### PR TITLE
Ignore NO_NODE errors when creating the consumer-topic map

### DIFF
--- a/lib/zookeeper.js
+++ b/lib/zookeeper.js
@@ -145,6 +145,11 @@ Zookeeper.prototype.getConsumersPerTopic = function (groupId, cb) {
                                 path,
                                 function (error, data) {
                                     if (error) {
+                                        // when NO_NODE happens here, a consumer has left abruptly
+                                        // and ZK doesn't know it yet
+                                        if(/NO_NODE/.test(error.toString())) {
+                                            cbb();
+                                        }
                                         cbb(error);
                                     }
                                     else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmf-kafka-node",
   "description": "node client for Apache kafka, only support kafka 0.8 and above",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "kafka.js",
   "dependencies": {
     "async": ">0.9 <2.0",


### PR DESCRIPTION
On each rebalance and free partition check, the driver constructs the
consumer-topic and topic-consumer maps. However, as each consumer path
is checked separately, the consumer might have disappeared in the
meantime (possibly without ZK noticing it). As losing consumers is
acceptable, don't abort the whole process and leave it in an
undeterministic state when that happens.
